### PR TITLE
fixed event only one return 

### DIFF
--- a/components/data-config/source_file.go
+++ b/components/data-config/source_file.go
@@ -89,7 +89,7 @@ func (f *SourceFile) newWatcher() {
 			case ev := <-f.watcher.Event:
 				{
 					if ev.IsDir() {
-						return
+						continue
 					}
 
 					configName := cfile.GetFileName(ev.FileInfo.Name(), true)

--- a/components/data-config/source_file.go
+++ b/components/data-config/source_file.go
@@ -8,6 +8,7 @@ import (
 	"github.com/radovskyb/watcher"
 	"os"
 	"time"
+	"regexp"
 )
 
 type (
@@ -39,6 +40,13 @@ func (f *SourceFile) Init(_ IDataConfig) {
 
 	f.watcher = watcher.New()
 	f.watcher.FilterOps(watcher.Write)
+	var regexpFilter * regexp.Regexp
+	regexpFilter,err = regexp.Compile(`.*\`+f.ExtName+`$`)
+	if err != nil {
+		clog.Panicf("AddFilterHook extName fail. err = %v", err)
+		return
+	}
+	f.watcher.AddFilterHook(watcher.RegexFilterHook(regexpFilter, false))
 
 	f.monitorPath, err = cfile.JoinPath(cprofile.Path(), f.FilePath)
 	if err != nil {


### PR DESCRIPTION
1.处理文件变动事件只处理一次会因为 dir 时间导致监听协程退出后不在监听
2.添加事件过滤 只处理扩展名后缀相关的事件