### PR TITLE
update:相互挤号a.write(pkg)并发问题修复

### DIFF
--- a/net/parser/pomelo/agent.go
+++ b/net/parser/pomelo/agent.go
@@ -421,8 +421,8 @@ func (a *Agent) Kick(reason interface{}, closed bool) {
 		)
 	}
 
-	// 不进入pending chan，直接踢了
-	a.write(pkg)
+	//a.write(pkg) 新的agent直接对旧的agent write会有并发问题
+	a.SendRaw(pkg)
 
 	if closed {
 		a.Close()

--- a/net/parser/pomelo/agents.go
+++ b/net/parser/pomelo/agents.go
@@ -65,7 +65,10 @@ func Unbind(sid cfacade.SID) {
 	}
 
 	delete(sidAgentMap, sid)
-	delete(uidMap, agent.UID())
+	//是否绑定了新的Sid,就不要删除uid了
+	if nowSid, ok := uidMap[agent.UID()]; ok && nowSid == sid {
+		delete(uidMap, agent.UID())
+	}
 
 	sidCount := len(sidAgentMap)
 	uidCount := len(uidMap)


### PR DESCRIPTION
不进入pending chan，直接a.write(pkg) 由于是新的agent去操作旧agent会导致并发，使用a.SendRaw(pkg)，由于先Bind uid 然后再执行Unbind，uidMap只有一个就不需要删除了